### PR TITLE
Unit test for receive failure after timeout

### DIFF
--- a/mqtt-client/src/test/java/org/fusesource/mqtt/client/BlockingApiTest.java
+++ b/mqtt-client/src/test/java/org/fusesource/mqtt/client/BlockingApiTest.java
@@ -69,6 +69,16 @@ public class BlockingApiTest extends BrokerTestSupport {
         } catch (Throwable e) {
             fail("Unexpected exception: "+e);
         }
+
+        // also test "" client id
+        mqtt.setClientId("");
+        try {
+            mqtt.blockingConnection();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+        } catch (Throwable e) {
+            fail("Unexpected exception: "+e);
+        }
     }
 
     public void testReceiveTimeout() throws Exception {


### PR DESCRIPTION
BlockingConnection.receive() stops working after a previous call times out. 
