### PR TITLE
on connect exception preserve the connack failure in the exception

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
@@ -359,7 +359,7 @@ public class CallbackConnection {
                                         mqtt.tracer.debug("MQTT login rejected");
                                         // Bad creds or something. No point in reconnecting.
                                         transport.stop(NOOP);
-                                        cb.onFailure(new IOException("Could not connect: " + connack.code()));
+                                        cb.onFailure(new MQTTException("Could not connect: " + connack.code(), connack));
                                 }
                                 break;
                             default:

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTTException.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTTException.java
@@ -1,0 +1,14 @@
+package org.fusesource.mqtt.client;
+
+import java.io.IOException;
+
+import org.fusesource.mqtt.codec.CONNACK;
+
+public class MQTTException extends IOException {
+  public final CONNACK connack;
+
+  public MQTTException(String msg, CONNACK connack) {
+    super(msg);
+    this.connack = connack;
+  }
+}


### PR DESCRIPTION
I find it awkward to pull out the cause of a disconnect on e.g. password failure. I've added a subclass of IOException that preserves the CONNACK code that caused the exception. Since an IOException is still thrown no changes are required in the callers.