### PR TITLE
Multiple quality improvements

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/cli/Publisher.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/cli/Publisher.java
@@ -163,7 +163,7 @@ public class Publisher {
                     File file = new File(shift(argl));
                     RandomAccessFile raf = new RandomAccessFile(file, "r");
                     try {
-                        byte data[] = new byte[(int) raf.length()];
+                        byte[] data = new byte[(int) raf.length()];
                         raf.seek(0);
                         raf.readFully(data);
                         main.body = new Buffer(data);

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
@@ -42,8 +42,8 @@ import static org.fusesource.hawtdispatch.Dispatch.createQueue;
  */
 public class MQTT {
 
-    private static final long KEEP_ALIVE = Long.parseLong(System.getProperty("mqtt.thread.keep_alive", ""+1000));
-    private static final long STACK_SIZE = Long.parseLong(System.getProperty("mqtt.thread.stack_size", ""+1024*512));
+    private static final long KEEP_ALIVE = Long.parseLong(System.getProperty("mqtt.thread.keep_alive", Integer.toString(1000)));
+    private static final long STACK_SIZE = Long.parseLong(System.getProperty("mqtt.thread.stack_size", Integer.toString(1024*512)));
     private static ThreadPoolExecutor blockingThreadPool;
 
 

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/Topic.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/Topic.java
@@ -50,8 +50,9 @@ public class Topic {
 
     @Override
     public boolean equals(Object o) {
+        if (o == null) return false;
+        if (o.getClass() != this.getClass()) return false;
         if (this == o) return true;
-        if (!(o instanceof Topic)) return false;
 
         Topic topic = (Topic) o;
 

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/MessageSupport.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/MessageSupport.java
@@ -33,7 +33,11 @@ import org.fusesource.mqtt.client.QoS;
  *
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
-public class MessageSupport {
+public final class MessageSupport {
+
+    private MessageSupport() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * All command objects implement this interface.

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBACK.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBACK.java
@@ -38,7 +38,7 @@ public class SUBACK implements Message {
     public static final byte TYPE = 9;
 
     private short messageId;
-    private byte grantedQos[] = NO_GRANTED_QOS;
+    private byte[] grantedQos = NO_GRANTED_QOS;
 
     public byte messageType() {
         return TYPE;

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBSCRIBE.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBSCRIBE.java
@@ -41,7 +41,7 @@ public class SUBSCRIBE extends MessageSupport.HeaderBase implements Message, Ack
     public static final Topic[] NO_TOPICS = new Topic[0];
 
     private short messageId;
-    private Topic topics[] = NO_TOPICS;
+    private Topic[] topics = NO_TOPICS;
 
     public SUBSCRIBE() {
         qos(QoS.AT_LEAST_ONCE);

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/UNSUBSCRIBE.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/UNSUBSCRIBE.java
@@ -41,7 +41,7 @@ public class UNSUBSCRIBE extends MessageSupport.HeaderBase implements Message, A
     public static final UTF8Buffer[] NO_TOPICS = new UTF8Buffer[0];
 
     private short messageId;
-    private UTF8Buffer topics[] = NO_TOPICS;
+    private UTF8Buffer[] topics = NO_TOPICS;
 
     public UNSUBSCRIBE() {
         qos(QoS.AT_LEAST_ONCE);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1118 - Utility classes should not have public constructors
squid:S1197 - Array designators "[]" should be on the type, not the variable
squid:S2131 - Primitives should not be boxed just for "String" conversion
squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat