### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/cli/Publisher.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/cli/Publisher.java
@@ -263,7 +263,7 @@ public class Publisher {
         });
 
         new Task() {
-            long sent = 0;
+            private long sent = 0;
             public void run() {
                 final Task publish = this;
                 Buffer message  = body;

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
@@ -75,9 +75,9 @@ import org.fusesource.mqtt.codec.UNSUBSCRIBE;
 public class CallbackConnection {
     
     private static class Request {
-        final MQTTFrame frame;
+        private final MQTTFrame frame;
         private final short id;
-        final Callback cb;
+        private final Callback cb;
 
         Request(int id, MQTTFrame frame, Callback cb) {
             this.id = (short) id;
@@ -317,7 +317,7 @@ public class CallbackConnection {
     }
 
     class LoginHandler implements Callback<Transport> {
-        final Callback<Void> cb;
+        private final Callback<Void> cb;
         private final boolean initialConnect;
 
         LoginHandler(Callback<Void> cb, boolean initialConnect) {
@@ -410,7 +410,7 @@ public class CallbackConnection {
         }
     }
 
-    boolean onRefillCalled =false;
+    private boolean onRefillCalled =false;
     public void onSessionEstablished(Transport transport) {
         this.transport = transport;
         if( suspendCount.get() > 0 ) {
@@ -535,7 +535,7 @@ public class CallbackConnection {
         disconnected = true;
         final short requestId = getNextMessageId();
         final Runnable stop = new Runnable() {
-            boolean executed = false;
+            private boolean executed = false;
             public void run() {
                 if(!executed) {
                     executed = true;
@@ -711,7 +711,7 @@ public class CallbackConnection {
         }
     }
 
-    short nextMessageId = 1;
+    private short nextMessageId = 1;
     private short getNextMessageId() {
         short rc = nextMessageId;
         nextMessageId++;

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/FutureConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/FutureConnection.java
@@ -42,7 +42,7 @@ public class FutureConnection {
     private final LinkedList<Promise<Message>> receiveFutures = new LinkedList<Promise<Message>>();
     private final LinkedList<Message> receivedFrames = new LinkedList<Message>();
 
-    volatile boolean connected;
+    private volatile boolean connected;
 
     public FutureConnection(CallbackConnection next) {
         this.next = next;

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
@@ -84,25 +84,25 @@ public class MQTT {
         }
     }
 
-    URI host = DEFAULT_HOST; 
-    URI localAddress;
-    SSLContext sslContext;
-    DispatchQueue dispatchQueue;
-    Executor blockingExecutor;
-    int maxReadRate;
-    int maxWriteRate;
-    int trafficClass = TcpTransport.IPTOS_THROUGHPUT;
-    int receiveBufferSize = 1024*64;
-    int sendBufferSize = 1024*64;
-    boolean useLocalHost = true;
-    CONNECT connect = new CONNECT();
+    protected URI host = DEFAULT_HOST;
+    protected URI localAddress;
+    protected SSLContext sslContext;
+    protected DispatchQueue dispatchQueue;
+    protected Executor blockingExecutor;
+    protected int maxReadRate;
+    protected int maxWriteRate;
+    protected int trafficClass = TcpTransport.IPTOS_THROUGHPUT;
+    protected int receiveBufferSize = 1024*64;
+    protected int sendBufferSize = 1024*64;
+    protected boolean useLocalHost = true;
+    protected CONNECT connect = new CONNECT();
 
-    long reconnectDelay = 10;
-    long reconnectDelayMax = 30*1000;
-    double reconnectBackOffMultiplier = 2.0f;
-    long reconnectAttemptsMax = -1;
-    long connectAttemptsMax = -1;
-    Tracer tracer = new Tracer();
+    protected long reconnectDelay = 10;
+    protected long reconnectDelayMax = 30*1000;
+    protected double reconnectBackOffMultiplier = 2.0f;
+    protected long reconnectAttemptsMax = -1;
+    protected long connectAttemptsMax = -1;
+    protected Tracer tracer = new Tracer();
 
     public MQTT() {
     }

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/Promise.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/Promise.java
@@ -31,9 +31,9 @@ import java.util.concurrent.TimeoutException;
 public class Promise<T> implements Callback<T>, Future<T> {
 
     private final CountDownLatch latch = new CountDownLatch(1);
-    Callback<T> next;
-    Throwable error;
-    T value;
+    private Callback<T> next;
+    private Throwable error;
+    private T value;
 
     public void onFailure(Throwable value) {
         Callback<T> callback = null;

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/MessageSupport.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/MessageSupport.java
@@ -76,7 +76,7 @@ public final class MessageSupport {
 
     static abstract public class AckBase {
 
-        short messageId;
+        private short messageId;
 
         abstract byte messageType();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat