### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
@@ -71,7 +71,10 @@ import static org.fusesource.hawtdispatch.Dispatch.createQueue;
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class CallbackConnection {
-    
+    private boolean onRefillCalled =false;
+    public static final Task NOOP = Dispatch.NOOP;
+    private short nextMessageId = 1;
+
     private static class Request {
         private final MQTTFrame frame;
         private final short id;
@@ -411,7 +414,6 @@ public class CallbackConnection {
         }
     }
 
-    private boolean onRefillCalled =false;
     public void onSessionEstablished(Transport transport) {
         this.transport = transport;
         if( suspendCount.get() > 0 ) {
@@ -741,7 +743,6 @@ public class CallbackConnection {
         }
     }
 
-    private short nextMessageId = 1;
     private short getNextMessageId() {
         short rc = nextMessageId;
         nextMessageId++;
@@ -857,8 +858,6 @@ public class CallbackConnection {
             handleFatalFailure(e);
         }
     }
-
-    static public final Task NOOP = Dispatch.NOOP;
 
     private void toReceiver(final PUBLISH publish) {
         if( listener !=null ) {

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/MQTT.java
@@ -45,44 +45,7 @@ public class MQTT {
     private static final long KEEP_ALIVE = Long.parseLong(System.getProperty("mqtt.thread.keep_alive", Integer.toString(1000)));
     private static final long STACK_SIZE = Long.parseLong(System.getProperty("mqtt.thread.stack_size", Integer.toString(1024*512)));
     private static ThreadPoolExecutor blockingThreadPool;
-
-
-    public synchronized static ThreadPoolExecutor getBlockingThreadPool() {
-        if( blockingThreadPool == null ) {
-            blockingThreadPool = new ThreadPoolExecutor(0, Integer.MAX_VALUE, KEEP_ALIVE, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(), new ThreadFactory() {
-                    public Thread newThread(Runnable r) {
-                        Thread rc = new Thread(null, r, "MQTT Task", STACK_SIZE);
-                        rc.setDaemon(true);
-                        return rc;
-                    }
-                }) {
-
-                    @Override
-                    public void shutdown() {
-                        // we don't ever shutdown since we are shared..
-                    }
-
-                    @Override
-                    public List<Runnable> shutdownNow() {
-                        // we don't ever shutdown since we are shared..
-                        return Collections.emptyList();
-                    }
-                };
-        }
-        return blockingThreadPool;
-    }
-    public synchronized static void setBlockingThreadPool(ThreadPoolExecutor pool) {
-        blockingThreadPool = pool;
-    }
-    
     private static final URI DEFAULT_HOST = createDefaultHost();
-    private static URI createDefaultHost() {
-        try {
-            return new URI("tcp://127.0.0.1:1883");
-        } catch (URISyntaxException e) {
-            return null;
-        }
-    }
 
     protected URI host = DEFAULT_HOST;
     protected URI localAddress;
@@ -125,6 +88,42 @@ public class MQTT {
         this.reconnectAttemptsMax = other.reconnectAttemptsMax;
         this.connectAttemptsMax = other.connectAttemptsMax;
         this.tracer = other.tracer;
+    }
+
+    public synchronized static ThreadPoolExecutor getBlockingThreadPool() {
+        if( blockingThreadPool == null ) {
+            blockingThreadPool = new ThreadPoolExecutor(0, Integer.MAX_VALUE, KEEP_ALIVE, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(), new ThreadFactory() {
+                    public Thread newThread(Runnable r) {
+                        Thread rc = new Thread(null, r, "MQTT Task", STACK_SIZE);
+                        rc.setDaemon(true);
+                        return rc;
+                    }
+                }) {
+
+                    @Override
+                    public void shutdown() {
+                        // we don't ever shutdown since we are shared..
+                    }
+
+                    @Override
+                    public List<Runnable> shutdownNow() {
+                        // we don't ever shutdown since we are shared..
+                        return Collections.emptyList();
+                    }
+                };
+        }
+        return blockingThreadPool;
+    }
+    public synchronized static void setBlockingThreadPool(ThreadPoolExecutor pool) {
+        blockingThreadPool = pool;
+    }
+
+    private static URI createDefaultHost() {
+        try {
+            return new URI("tcp://127.0.0.1:1883");
+        } catch (URISyntaxException e) {
+            return null;
+        }
     }
 
     public CallbackConnection callbackConnection() {

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/PUBREL.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/PUBREL.java
@@ -38,12 +38,12 @@ public class PUBREL extends MessageSupport.HeaderBase implements Message, Acked 
 
     private short messageId;
 
-    public byte messageType() {
-        return TYPE;
-    }
-    
     public PUBREL() {
         qos(QoS.AT_LEAST_ONCE);
+    }
+
+    public byte messageType() {
+        return TYPE;
     }
 
     public PUBREL decode(MQTTFrame frame) throws ProtocolException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat