### PR TITLE
Handling SUBACK with Failure code

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
@@ -51,10 +51,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ProtocolException;
 import java.net.SocketAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -800,6 +797,30 @@ public class CallbackConnection {
         }
     }
 
+    private void completeRequestSubAck(short id, byte[] grantedQos) throws ProtocolException {
+        Request request = requests.remove(id);
+        if( request!=null ) {
+            assert SUBSCRIBE.TYPE==request.frame.messageType();
+            if(request.cb!=null) {
+                ArrayList<String> rejectedTopics = new ArrayList<String>(grantedQos.length);
+                for (int i = 0; i < grantedQos.length; i++) {
+                    if(SUBACK.isFailureQos(grantedQos[i])) {
+                        rejectedTopics.add(new SUBSCRIBE().decode(request.frame).topics()[i].toString());
+                    }
+                }
+
+                if(!rejectedTopics.isEmpty()) {
+                    ((Callback<Void>)request.cb).onFailure(new ProtocolException("Server rejected subscribe to: " + Arrays.toString(rejectedTopics.toArray())));
+                }
+                if(rejectedTopics.size() < grantedQos.length) {
+                    ((Callback<Object>) request.cb).onSuccess(grantedQos);
+                }
+            }
+        } else {
+            handleFatalFailure(new ProtocolException("Command from server contained an invalid message id: " + id));
+        }
+    }
+
     private void processFrame(MQTTFrame frame) {
         try {
             switch(frame.messageType()) {
@@ -838,7 +859,7 @@ public class CallbackConnection {
                 }
                 case SUBACK.TYPE: {
                     SUBACK ack = new SUBACK().decode(frame);
-                    completeRequest(ack.messageId(), SUBSCRIBE.TYPE, ack.grantedQos());
+                    completeRequestSubAck(ack.messageId(), ack.grantedQos());
                     break;
                 }
                 case UNSUBACK.TYPE: {

--- a/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBACK.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/codec/SUBACK.java
@@ -37,6 +37,8 @@ public class SUBACK implements Message {
     public static final byte[] NO_GRANTED_QOS = new byte[0];
     public static final byte TYPE = 9;
 
+    private static final byte FAILURE_QOS = (byte)0x80;
+
     private short messageId;
     private byte[] grantedQos = NO_GRANTED_QOS;
 
@@ -68,6 +70,10 @@ public class SUBACK implements Message {
 
     public byte[] grantedQos() {
         return grantedQos;
+    }
+
+    public static boolean isFailureQos(byte grantedQos) {
+        return grantedQos == FAILURE_QOS;
     }
 
     public SUBACK grantedQos(byte[] grantedQos) {


### PR DESCRIPTION
Whenever my broker rejects a Subscribe (because it was not authorized) it'll send the code 0x80 replacing the QoS in the SUBACK. 
(See MQTT 3.1.1 Protocol SUBACK http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718068) 
But this mqtt client does not handle SUBACK codes, it only accepts any SUBACK as a subscription confirmation.

I made a change to verify if any of the returned QoS codes is 0x80 (there can be multiple topics in the requested Subscribe) and then call the Failure Callback if there is at least one. 
So, it'll be possible to have both callbacks being called when some topics are accepted and others rejected.

Also, the Failure Callback does not support any other parameter asside from an exception.
So there's no way to acquire the failed topic in the callback. But it is possible to verify the QoS codes (passed as parameter) in the success callback.

This verification is compatible with MQTT 3.1.