### PR TITLE
Fix the reconnect bug.

### DIFF
--- a/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
+++ b/mqtt-client/src/main/java/org/fusesource/mqtt/client/CallbackConnection.java
@@ -204,7 +204,6 @@ public class CallbackConnection {
                         send(request);
                     }
 
-                    reconnects = 0;
                     isReconnecting.set(false);
                 }
 


### PR DESCRIPTION
## Motivation
If we reset reconnects = 0 in reconnect method, this would cause the client to reconnect indifinitely event if we set setReconnectAttemptsMax = 1.